### PR TITLE
Add MG5@NLO 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# v0.1.0
+	- Add MG5aMG 3.3.0
+	- Add Pythia8.306
+	- Add MG5aMC_PY8_interface 1.3 (For Py8.306)
+	- Install LHDAPDF library with Python 3.8 bindings
+	- Install python38-numpy and python38-numpy-f2py for reweight module
+
+# v0.0.2
+	- Change default python to 3.8
+	- Add LHDAPDF libraries (via yum)
+
+# v0.0.1
+	- Basic MG5@NLO+Py8+Delphes

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,25 @@ RUN yum -y install yum-utils && \
     yum -y install gcc-gfortran
 
 # Install random HEP tools
-RUN yum -y install HepMC-devel lhapdf-devel gnuplot
+RUN yum -y install HepMC-devel  gnuplot
 
 # Install ROOT
 RUN yum -y install root root-montecarlo-eg root-graf3d-eve root-gui-html root-genvector
+
+# Install LHAPDF
+RUN wget -O LHAPDF-6.4.0.tar.gz https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.4.0.tar.gz && \
+    tar -xvzf LHAPDF-6.4.0.tar.gz && \
+    rm LHAPDF-6.4.0.tar.gz && \
+    pushd LHAPDF-6.4.0 && \
+    ./configure --prefix=/opt/LHAPDF/6.4.0 && \
+    make && \
+    make install &&\
+    popd && rm -rf LHAPDF-6.4.0 && \
+    DATADIR=$(/opt/LHAPDF/6.4.0/bin/lhapdf-config --datadir) && \
+    wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/CT10nlo.tar.gz -O- | tar xz -C ${DATADIR} && \
+    wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/NNPDF30_nlo_as_0118.tar.gz -O- | tar xz -C ${DATADIR} && \
+    wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/NNPDF30_nnlo_as_0118.tar.gz -O- | tar xz -C ${DATADIR} && \
+    wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/NNPDF23_nlo_as_0119.tar.gz -O- | tar xz -C ${DATADIR}
 
 # Install MadGraph
 RUN wget https://launchpad.net/mg5amcnlo/3.0/3.2.x/+download/MG5_aMC_v3.2.0.tar.gz && \
@@ -36,14 +51,6 @@ RUN wget https://launchpad.net/mg5amcnlo/3.0/3.3.x/+download/MG5_aMC_v3.3.0.tar.
     mv MG5_aMC_v3_3_0 /opt/MG5aMC/3.3.0
 
 # Install Pythia 8
-RUN wget https://pythia.org/download/pythia83/pythia8306.tgz && \
-    tar -xzf pythia8306.tgz && \
-    rm pythia8306.tgz && \
-    pushd pythia8306 && \
-    ./configure --with-hepmc2 --with-gzip --prefix=/opt/pythia/8.306 && \
-    make && make install && \
-    popd && rm -rf pythia8306
-
 RUN wget https://pythia.org/download/pythia82/pythia8245.tgz && \
     tar -xzf pythia8245.tgz && \
     rm pythia8245.tgz && \
@@ -51,6 +58,14 @@ RUN wget https://pythia.org/download/pythia82/pythia8245.tgz && \
     ./configure --with-hepmc2 --with-gzip --prefix=/opt/pythia/8.245 && \
     make && make install && \
     popd && rm -rf pythia8245
+
+RUN wget https://pythia.org/download/pythia83/pythia8306.tgz && \
+    tar -xzf pythia8306.tgz && \
+    rm pythia8306.tgz && \
+    pushd pythia8306 && \
+    ./configure --with-hepmc2 --with-gzip --prefix=/opt/pythia/8.306 && \
+    make && make install && \
+    popd && rm -rf pythia8306
 
 # MG/Py8 interface (specific to Pythia version)
 RUN wget http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/MG5aMC_PY8_interface_V1.2.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:8
 RUN yum -y install yum-utils && \
     yum-config-manager --set-enabled powertools && \
     yum -y install epel-release wget cmake libarchive rsync && \
-    yum -y install python38 python38-six && \
+    yum -y install python38 python38-six python38-numpy python38-numpy-f2py && \
     alternatives --set python /usr/bin/python3.8 && \
     alternatives --set python3 /usr/bin/python3.8 && \
     yum -y groupinstall "Development Tools" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,15 @@ RUN wget https://launchpad.net/mg5amcnlo/3.0/3.2.x/+download/MG5_aMC_v3.2.0.tar.
     pushd && \
     mv MG5_aMC_v3_2_0 /opt/MG5aMC/3.2.0
 
+RUN wget https://launchpad.net/mg5amcnlo/3.0/3.3.x/+download/MG5_aMC_v3.3.0.tar.gz && \
+    tar -xf MG5_aMC_v3.3.0.tar.gz && \
+    rm MG5_aMC_v3.3.0.tar.gz && \
+    mkdir -p /opt/MG5aMC && \
+    pushd MG5_aMC_v3_3_0 && \
+    rsync -ar Template/LO/Source/.make_opts Template/LO/Source/make_opts && \
+    pushd && \
+    mv MG5_aMC_v3_3_0 /opt/MG5aMC/3.3.0
+
 # Install Pythia 8
 RUN wget https://pythia.org/download/pythia83/pythia8306.tgz && \
     tar -xzf pythia8306.tgz && \
@@ -55,6 +64,17 @@ RUN wget http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/MG5
     install PYTHIA8_VERSION_ON_INSTALL /opt/pythia/8.245 && \
     popd && rm -rf MG5aMC_PY8_interface_V1.2
 
+RUN wget http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/MG5aMC_PY8_interface_V1.3.tar.gz && \
+    mkdir MG5aMC_PY8_interface_V1.3 && \
+    tar -xf MG5aMC_PY8_interface_V1.3.tar.gz -C MG5aMC_PY8_interface_V1.3 && \
+    rm MG5aMC_PY8_interface_V1.3.tar.gz && \
+    pushd MG5aMC_PY8_interface_V1.3 && \
+    python3.8 compile.py /opt/pythia/8.306/ --pythia8_makefile && \
+    install MG5aMC_PY8_interface /opt/pythia/8.306 && \
+    install MG5AMC_VERSION_ON_INSTALL /opt/pythia/8.306 && \
+    install PYTHIA8_VERSION_ON_INSTALL /opt/pythia/8.306 && \
+    popd && rm -rf MG5aMC_PY8_interface_V1.3
+
 # Install ExRootAnalysis
 RUN wget http://madgraph.phys.ucl.ac.be/Downloads/ExRootAnalysis/ExRootAnalysis_V1.1.5.tar.gz && \
     tar -xf ExRootAnalysis_V1.1.5.tar.gz && \
@@ -82,3 +102,9 @@ RUN sed -i -e 's|[# ]*f2py_compiler_py3\s*=\s*.*|f2py_compiler_py3 = /usr/bin/f2
     sed -i -e 's|[# ]*pythia8_path\s*=\s*.*|pythia8_path = /opt/pythia/8.245|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt && \
     sed -i -e 's|[# ]*exrootanalysis_path\s*=\s*.*|exrootanalysis_path = /opt/ExRootAnalysis/1.1.5/bin|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt && \
     sed -i -e 's|[# ]*delphes_path\s*=\s*.*|delphes_path = /opt/delphes/3.5.0/bin|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt
+
+RUN sed -i -e 's|[# ]*f2py_compiler_py3\s*=\s*.*|f2py_compiler_py3 = /usr/bin/f2py3|' /opt/MG5aMC/3.3.0/input/mg5_configuration.txt && \
+    sed -i -e 's|[# ]*mg5amc_py8_interface_path\s*=\s*.*|mg5amc_py8_interface_path = /opt/pythia/8.306|' /opt/MG5aMC/3.3.0/input/mg5_configuration.txt && \
+    sed -i -e 's|[# ]*pythia8_path\s*=\s*.*|pythia8_path = /opt/pythia/8.306|' /opt/MG5aMC/3.3.0/input/mg5_configuration.txt && \
+    sed -i -e 's|[# ]*exrootanalysis_path\s*=\s*.*|exrootanalysis_path = /opt/ExRootAnalysis/1.1.5/bin|' /opt/MG5aMC/3.3.0/input/mg5_configuration.txt && \
+    sed -i -e 's|[# ]*delphes_path\s*=\s*.*|delphes_path = /opt/delphes/3.5.0/bin|' /opt/MG5aMC/3.3.0/input/mg5_configuration.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install yum-utils && \
     yum -y install gcc-gfortran
 
 # Install random HEP tools
-RUN yum -y install HepMC-devel  gnuplot
+RUN yum -y install HepMC-devel gnuplot
 
 # Install ROOT
 RUN yum -y install root root-montecarlo-eg root-graf3d-eve root-gui-html root-genvector
@@ -21,15 +21,14 @@ RUN wget -O LHAPDF-6.4.0.tar.gz https://lhapdf.hepforge.org/downloads/?f=LHAPDF-
     tar -xvzf LHAPDF-6.4.0.tar.gz && \
     rm LHAPDF-6.4.0.tar.gz && \
     pushd LHAPDF-6.4.0 && \
-    ./configure --prefix=/opt/LHAPDF/6.4.0 && \
+    ./configure --prefix=/usr && \
     make && \
     make install &&\
     popd && rm -rf LHAPDF-6.4.0 && \
-    DATADIR=$(/opt/LHAPDF/6.4.0/bin/lhapdf-config --datadir) && \
-    wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/CT10nlo.tar.gz -O- | tar xz -C ${DATADIR} && \
-    wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/NNPDF30_nlo_as_0118.tar.gz -O- | tar xz -C ${DATADIR} && \
-    wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/NNPDF30_nnlo_as_0118.tar.gz -O- | tar xz -C ${DATADIR} && \
-    wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/NNPDF23_nlo_as_0119.tar.gz -O- | tar xz -C ${DATADIR}
+    lhapdf install CT10nlo && \
+    lhapdf install NNPDF30_nlo_as_0118 && \
+    lhapdf install NNPDF30_nnlo_as_0118 && \
+    lhapdf install NNPDF23_nlo_as_0119
 
 # Install MadGraph
 RUN wget https://launchpad.net/mg5amcnlo/3.0/3.2.x/+download/MG5_aMC_v3.2.0.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,8 @@ RUN git clone https://github.com/delphes/delphes.git && \
     popd && rm -rf delphes
 
 # Configure MG5@NLO to use external paths
-RUN sed -i -e 's|[# ]*mg5amc_py8_interface_path\s*=\s*.*|mg5amc_py8_interface_path = /opt/pythia/8.245|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt && \
+RUN sed -i -e 's|[# ]*f2py_compiler_py3\s*=\s*.*|f2py_compiler_py3 = /usr/bin/f2py3|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt && \
+    sed -i -e 's|[# ]*mg5amc_py8_interface_path\s*=\s*.*|mg5amc_py8_interface_path = /opt/pythia/8.245|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt && \
     sed -i -e 's|[# ]*pythia8_path\s*=\s*.*|pythia8_path = /opt/pythia/8.245|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt && \
     sed -i -e 's|[# ]*exrootanalysis_path\s*=\s*.*|exrootanalysis_path = /opt/ExRootAnalysis/1.1.5/bin|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt && \
     sed -i -e 's|[# ]*delphes_path\s*=\s*.*|delphes_path = /opt/delphes/3.5.0/bin|' /opt/MG5aMC/3.2.0/input/mg5_configuration.txt

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 Collection of programs for event generation/simulation for HEP experiments.
 
 # Included software
-- MG5@NLO 3.2.0
+- MG5@NLO 3.2.0 and 3.3.0
 - Pythia 8.306 and 8.245
-- MG5aMC_PY8_interface 1.2 (for Py8.245 only)
+- MG5aMC_PY8_interface 1.2 (MGg3.2.0 + Py8.245)
+- MG5aMC_PY8_interface 1.3 (MGg3.3.0 + Py8.306)
 - ExRootAnalysis 1.1.5
 - Delphes 3.5.0
 

--- a/example.sh
+++ b/example.sh
@@ -2,8 +2,8 @@
 
 me=$(pwd)
 
-/opt/MG5aMC/3.2.0/bin/mg5_aMC < ${me}/Cards/dijet.proc
+/opt/MG5aMC/3.3.0/bin/mg5_aMC < ${me}/Cards/dijet.proc
 ./PROC_dijet/bin/generate_events -f
 pushd PROC_dijet/Events/run_01
-/opt/pythia/8.245/MG5aMC_PY8_interface ${me}/Cards/shower.cmd
+/opt/pythia/8.306/MG5aMC_PY8_interface ${me}/Cards/shower.cmd
 /opt/delphes/3.5.0/bin/DelphesHepMC2 ${me}/Cards/delphes_card_default.dat delphes.root tag_1_pythia8_events.hepmc


### PR DESCRIPTION
Comes with MG5aMC_PY8_interface v1.3 that interfaces with latest Pythia 8.306.

Also use a custom installation of LHAPDF 4.6.0 installed to `/usr`. This fixes missing Python 3.8 bindings.