### PR TITLE
Add heft model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 	- Add MG5aMC_PY8_interface 1.3 (For Py8.306)
 	- Install LHDAPDF library with Python 3.8 bindings
 	- Install python38-numpy and python38-numpy-f2py for reweight module
+	- Download heft model
 
 # v0.0.2
 	- Change default python to 3.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ RUN wget https://launchpad.net/mg5amcnlo/3.0/3.3.x/+download/MG5_aMC_v3.3.1.tar.
     pushd && \
     mv MG5_aMC_v3_3_1 /opt/MG5aMC/3.3.1
 
+# Install MadGraph models
+ADD installModel.sh .
+RUN ./installModel.sh http://madgraph.phys.ucl.ac.be/Downloads/models/heft.tgz
+
 # Install Pythia 8
 RUN wget https://pythia.org/download/pythia82/pythia8245.tgz && \
     tar -xzf pythia8245.tgz && \

--- a/installModel.sh
+++ b/installModel.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [  ${#} != 1 ]; then
+    echo "usage: ${0} model"
+    exit 1
+fi
+
+model=${1}
+
+modelfile=$(basename ${model})
+
+wget ${model}
+
+for mg5path in /opt/MG5aMC/*
+do
+    tar -xvf ${modelfile} -C ${mg5path}/models/
+    modelpath=$(ls -td ${mg5path}/models/* | tail -1)
+    echo "convert model ${modelpath}" | ${mg5path}/bin/mg5_aMC
+done
+
+rm ${modelfile}
+


### PR DESCRIPTION
Also add a new `installModel.sh` script that download a MG5 model and installs it to all found MadGraph versions under `/opt/MG5aMC`.

Model conversion to python3 is automatically done.